### PR TITLE
[repo] Prepare release core-1.9.0-beta.2

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 * The experimental APIs previously covered by `OTEL1000`
   (`LoggerProviderBuilder` `AddInstrumentation` & `ConfigureServices` extensions
   and `IServiceCollection.ConfigureOpenTelemetryLoggerProvider` extension) will

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 * The experimental APIs previously covered by `OTEL1000` (`LoggerProvider`,
   `LoggerProviderBuilder`, & `IDeferredLoggerProviderBuilder`) will now be part
   of the public API and supported in stable builds.

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 * The experimental APIs previously covered by `OTEL1000`
   (`LoggerProviderBuilder.AddConsoleExporter` extension) will now be part of the
   public API and supported in stable builds.

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 * The experimental APIs previously covered by `OTEL1000`
   (`LoggerProviderBuilder.AddInMemoryExporter` extension) will now be part of
   the public API and supported in stable builds.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 * The experimental APIs previously covered by `OTEL1000`
   (`LoggerProviderBuilder.AddOtlpExporter` extension) will now be part of the
   public API and supported in stable builds.

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 ## 1.9.0-alpha.1
 
 Released 2024-May-20

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 * The experimental APIs previously covered by `OTEL1000`
   (`OpenTelemetryBuilder.WithLogging` method) will now be part of the public API
   and supported in stable builds.

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 ## 1.9.0-alpha.1
 
 Released 2024-May-20

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-beta.2
+
+Released 2024-Jun-07
+
 * The experimental APIs previously covered by `OTEL1000`
   (`LoggerProviderBuilder` `AddProcessor` & `ConfigureResource` extensions, and
   `LoggerProvider` `ForceFlush` & `Shutdown` extensions) will now be part of the


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

## Changes

* CHANGELOG files updated for projects being released.