### PR TITLE
[release] Prepare release core-1.9.0-rc.2

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.9.0-rc.2
+
+Released 2024-Jun-08
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

## Changes

* CHANGELOG files updated for projects being released.