### PR TITLE
[release] Core stable release 1.10.0 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <OTelLatestStableVer>[1.9.0,2.0)</OTelLatestStableVer>
+    <OTelLatestStableVer>[1.10.0,2.0)</OTelLatestStableVer>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Note: This PR was opened automatically by the [post-release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/post-release.yml).

Merge once packages are available on NuGet and the build passes.

## Changes

* Sets `OTelLatestStableVer` in `Directory.Packages.props` to `1.10.0`.