### PR TITLE
[release] Core stable release 1.10.0 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
+    <OTelLatestStableVer>1.10.0</OTelLatestStableVer>
   </PropertyGroup>
 
   <!--

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#51](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/51))
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-14
@@ -117,12 +120,15 @@ Released 2022-Sep-29
 * Bug fix for Prometheus Exporter reporting StatusCode 204
   instead of 200, when no metrics are collected
   ([#3643](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3643))
+
 * Added overloads which accept a name to the `MeterProviderBuilder`
   `AddPrometheusExporter` extension to allow for more fine-grained options
   management
   ([#3648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3648))
+
 * Added support for OpenMetrics UNIT metadata
   ([#3651](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3651))
+
 * Added `"# EOF\n"` ending following the [OpenMetrics
   specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md)
   ([#3654](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3654))
@@ -137,6 +143,7 @@ Released 2022-Aug-18
   ([#3430](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3430)
   [#3503](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3503)
   [#3507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3507))
+
 * Added `IEndpointRouteBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3295](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3295))
@@ -156,8 +163,10 @@ Released 2022-Apr-15
 * Added `IApplicationBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3029](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3029))
+
 * Changed Prometheus exporter to return 204 No Content and log a warning event
   if there are no metrics to collect.
+
 * Removes .NET Framework 4.6.1. The minimum .NET Framework
   version supported is .NET 4.6.2. ([#3190](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3190))
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#51](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/51))
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-14
@@ -114,12 +117,15 @@ Released 2022-Sep-29
 * Bug fix for Prometheus Exporter reporting StatusCode 204
   instead of 200, when no metrics are collected
   ([#3643](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3643))
+
 * Added overloads which accept a name to the `MeterProviderBuilder`
   `AddPrometheusHttpListener` extension to allow for more fine-grained options
   management
   ([#3648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3648))
+
 * Added support for OpenMetrics UNIT metadata
   ([#3651](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3651))
+
 * Added `"# EOF\n"` ending following the [OpenMetrics
   specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md)
   ([#3654](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3654))
@@ -134,6 +140,7 @@ Released 2022-Aug-18
   ([#3430](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3430)
   [#3503](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3503)
   [#3507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3507))
+
 * Fixed bug
   [#2840](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2840) by
   allowing `+` and `*` to be used in the URI prefixes (e.g. `"http://*:9184"`).
@@ -154,8 +161,10 @@ Released 2022-Apr-15
 * Added `IApplicationBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3029](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3029))
+
 * Changed Prometheus exporter to return 204 No Content and log a warning event
   if there are no metrics to collect.
+
 * Removes .NET Framework 4.6.1. The minimum .NET Framework
   version supported is .NET 4.6.2. ([#3190](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3190))
 

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#51](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/51))
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-14
@@ -30,6 +33,7 @@ Released 2023-Sep-05
 * Fix: Do not raise `ArgumentException` if `Activity` behind the shim span
   has an invalid context.
   ([#2787](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2787))
+
 * Obsolete `TracerShim(Tracer, TextMapPropagator)` constructor.
   Provide `TracerShim(TracerProvider)`
   and `TracerShim(TracerProvider, TextMapPropagator)` constructors.


### PR DESCRIPTION
Note: This PR was opened automatically by the [post-release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/post-release.yml).

Merge once packages are available on NuGet and the build passes.

## Changes

* Sets `OTelLatestStableVer` in `Directory.Packages.props` to `1.10.0`.