### PR TITLE
[release] Prepare release core-1.10.0-alpha.1

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-22
+
 ## 1.9.0
 
 Released 2024-Jun-14


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

Requested by: @CodeBlanch

## Changes

* CHANGELOG files updated for projects being released.
## Commands

/UpdateReleaseDates: Use to update release dates in CHANGELOGs before merging [pprovers, maintainers]
/CreateReleaseTag: Use after merging to push the release tag [pprovers, maintainers]
/PushPackages: Use after the release tag has been pushed and packages have been created [maintainers]