### PR TITLE
[release] Prepare release core-1.10.0

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 * **Breaking change**: Non-primitive attribute (logs) and tag (traces) values
   converted using `Convert.ToString` will now format using
   `CultureInfo.InvariantCulture`.

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 * **Breaking change**: Non-primitive tag values converted using
   `Convert.ToString` will now format using `CultureInfo.InvariantCulture`.
   ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0
+
+Released 2024-Jun-26
+
 ## 1.9.0
 
 Released 2024-Jun-14


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

Requested by: @CodeBlanch

## Changes

* CHANGELOG files updated for projects being released.
* Public API files updated for projects being released (only performed for stable releases).
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages [`approvers`, `maintainers`]
`/PushPackages`: Use after the created packages have been validated to push to NuGet [`maintainers`]