### PR TITLE
[release] Prepare release core-1.12.0

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,11 +6,7 @@ directory of each individual package.
 
 ## 1.12.0
 
-* Added some new features.
-* Did some cool things...
-  * Cool thing 1
-  * Cool thing 2
-  * Cool thing 3
+* Nothing in this release
 
 ## 1.11.0
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,14 @@ This file contains highlights and announcements covering all components.
 For more details see `CHANGELOG.md` files maintained in the root source
 directory of each individual package.
 
+## 1.12.0
+
+* Added some new features.
+* Did some cool things...
+  * Cool thing 1
+  * Cool thing 2
+  * Cool thing 3
+
 ## 1.11.0
 
 * `OpenTelemetry.Exporter.OpenTelemetryProtocol` no longer depends on the

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -6,6 +6,10 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.0
+
+Released 2025-Jan-17
+
 ## 1.11.0
 
 Released 2025-Jan-15


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

Requested by: @CodeBlanch

## Changes

* CHANGELOG files updated for projects being released.
* Public API files updated for projects being released (only performed for stable releases).
## Commands
`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/UpdateReleaseNotes`: Use to update `RELEASENOTES.md` before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages [`approvers`, `maintainers`]
`/PushPackages`: Use after the created packages have been validated to push to NuGet [`maintainers`]