### PR TITLE
[release] Prepare release core-1.11.0

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,10 +6,7 @@ directory of each individual package.
 
 ## 1.11.0
 
-* `OpenTelemetry.Exporter.OpenTelemetryProtocol` no longer depends on the
-  `Google.Protobuf`, `Grpc`, or `Grpc.Net.Client` packages. Serialization and
-  transmission of outgoing data is now performed manually to improve the overall
-  performance.
+* Replace 1.11.0 content
 
 ## 1.10.0
 

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -9,6 +9,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -8,6 +8,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -8,6 +8,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -8,6 +8,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -9,6 +9,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -8,6 +8,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -8,6 +8,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -8,6 +8,10 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 ## 1.11.0-rc.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -8,6 +8,10 @@ Notes](../../RELEASENOTES.md).
 
 ## 1.11.0
 
+Released 2025-Jan-17
+
+## 1.11.0
+
 Released 2025-Jan-15
 
 * [Meter.Tags](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics.meter.tags?view=net-9.0)


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

Requested by: @CodeBlanch

## Changes

* CHANGELOG files updated for projects being released.
* Public API files updated for projects being released (only performed for stable releases).
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/UpdateReleaseNotes`: Use to update `RELEASENOTES.md` before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages [`approvers`, `maintainers`]
`/PushPackages`: Use after the created packages have been validated to push to NuGet [`maintainers`]